### PR TITLE
(AZUREVAVS-64) Reconfigure metadata installation

### DIFF
--- a/sas-9.4m7-VA-MPP/ansible/install_sas.yaml
+++ b/sas-9.4m7-VA-MPP/ansible/install_sas.yaml
@@ -1,52 +1,35 @@
 ---
-- name: install sas on metadata servers
-  hosts: [metadata_servers,va_controllers,midtier_servers]
-  become: yes
-  gather_facts: false
-  tasks:
-     - name: Run metadata server and vacontroller install response file(s)
-       become: yes
-       shell: >-
-         /sasshare/scripts/run_install_as_user.sh sasinst /sasshare/responsefiles/{{ inventory_hostname }}_install.txt
-
-- name: Run setuid
-  hosts: [metadata_servers]
+- name: install sas on midtier, metadata head and vacontroller nodes
+  hosts: [va_controllers,midtier_servers,metadata_head]
   become: yes
   gather_facts: false
   vars_files:
     - /tmp/ansible_vars.yaml
   tasks:
-     - name: Run setuid.sh on the metadata nodes
+     - name: Run metadata head, midtier and vacontroller install response file(s)
        become: yes
-       shell: >-
-         {{ sasFolder }}/SASHome/SASFoundation/9.4/utilities/bin/setuid.sh
+       shell: |
+         /sasshare/scripts/run_install_as_user.sh sasinst /sasshare/responsefiles/{{ inventory_hostname }}_install.txt
+         # For metadata head node, run config step as well
+         if [[ "{{ inventory_hostname }}" == *"metadata"* ]]; then
+           {{ sasFolder }}/SASHome/SASFoundation/9.4/utilities/bin/setuid.sh
+           /sasshare/scripts/run_install_as_user.sh sasinst /sasshare/responsefiles/{{ inventory_hostname }}_config.txt
+         fi
 
-- name: configure sas on metadata head
-  hosts: [metadata_head]
-  become: yes
-  gather_facts: false
-  tasks:
-     - name: Run metadata head config response file
-       become: yes
-       shell: >-
-         /sasshare/scripts/run_install_as_user.sh sasinst /sasshare/responsefiles/{{ inventory_hostname }}_config.txt
-     - name: Pause for 5 minutes between metadata server configurations
-       pause:
-         minutes: 5
-
-- name: configure sas on metadata nodes
+- name: install and configure sas on metadata nodes
   hosts: [metadata_nodes]
   serial: 1
   become: yes
   gather_facts: false
+  vars_files:
+    - /tmp/ansible_vars.yaml
   tasks:
-     - name: Run metadata node config response file
-       become: yes
-       shell: >-
-         /sasshare/scripts/run_install_as_user.sh sasinst /sasshare/responsefiles/{{ inventory_hostname }}_config.txt
-     - name: Pause for 5 minutes between metadata server configurations
-       pause:
-         minutes: 5
+    - name: Run metadata install and config response files
+      become: yes
+      shell: |
+        /sasshare/scripts/run_install_as_user.sh sasinst /sasshare/responsefiles/{{ inventory_hostname }}_install.txt
+        {{ sasFolder }}/SASHome/SASFoundation/9.4/utilities/bin/setuid.sh
+        /sasshare/scripts/run_install_as_user.sh sasinst /sasshare/responsefiles/{{ inventory_hostname }}_config.txt
 
 - name: configure sas on visual analytics controller
   hosts: [va_controllers]


### PR DESCRIPTION
Reconfigure metadata cluster installation so that the install and config steps are performed in tandem for each node. This prevents the metadata server restarts from happening while nodes are configured.

Check these items before submitting a PR... 

[Contribution Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md)

[Best Practice Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md)


- [ ] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

## Changelog

*
*
*
