### PR TITLE
(AZUREVIYA-321) upgrade pip3

### DIFF
--- a/sas-viya/scripts/ansiblecontroller_prereqs.sh
+++ b/sas-viya/scripts/ansiblecontroller_prereqs.sh
@@ -36,6 +36,7 @@ sed -i -e '/Defaults    requiretty/{ s/.*/# Defaults    requiretty/ }' /etc/sudo
 echo "$(date)"
 echo "Creating the share on the storage account."
 yum install -y rh-python36 gcc time
+/opt/rh/rh-python36/root/usr/bin/pip install --upgrade pip
 /opt/rh/rh-python36/root/usr/bin/pip3 install azure-cli
 /opt/rh/rh-python36/root/usr/bin/az storage share create --name ${azure_storage_files_share} --connection-string "DefaultEndpointsProtocol=https;EndpointSuffix=core.windows.net;AccountName=${azure_storage_account};AccountKey=${azure_storage_files_password}"
 


### PR DESCRIPTION
Older version of python3 pip3 is failing to install azure-cli.  Upgrading to latest version of pip fixes this issue.

# PR Checklist

Check these items before submitting a PR... 

[Contribution Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md)

[Best Practice Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md)


- [ x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

## Changelog

*
*
*
